### PR TITLE
Hotfix: register missing migrations 017 and 018

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -142,7 +142,9 @@ async function runMigrationsOnStartup() {
       '013-add-employer-approval.sql',
       '014-add-employee-profile-fields.sql',
       '015-contract-version-and-oracle-addresses.sql',
-      '016-offer-signature.sql'
+      '016-offer-signature.sql',
+      '017-allow-repeat-contracts-per-worker.sql',
+      '018-fix-email-wallet-constraints.sql'
     ];
 
     for (const file of migrationFiles) {


### PR DESCRIPTION
## Summary
- Migrations 017 and 018 were merged to main but never added to the explicit migration list in `server.js`, so they never ran on production
- This adds both to the list so they execute on next deploy

| Migration | What it does |
|-----------|-------------|
| 017 | Replaces blanket `UNIQUE(job_posting_id, employee_id)` with a partial index — allows a worker to be re-hired on the same job after a contract completes/terminates |
| 018 | Drops `UNIQUE` on `email` (wrong anchor), adds `UNIQUE` on `wallet_address` in both `employee` and `employer` tables (#41) |

Both migrations are idempotent (`DROP CONSTRAINT IF EXISTS`, `CREATE UNIQUE INDEX IF NOT EXISTS`) — safe to run against any state of the DB.

## Test plan
- [ ] Merge and deploy — confirm startup logs show `📄 Running 017-allow-repeat-contracts-per-worker.sql...` and `📄 Running 018-fix-email-wallet-constraints.sql...`
- [ ] Verify no errors in deploy logs (both are no-ops if already applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)