### PR TITLE
feat(#50): worker profile buildout — Tier 2 fields + completeness bar

### DIFF
--- a/client/src/EmployeePages/EmployeeProfile.jsx
+++ b/client/src/EmployeePages/EmployeeProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import img from '../assets/profile.webp';
 import EmployeeNavbar from "../components/EmployeeNavbar";
 import { useAuth } from "../hooks/useAuth";
@@ -41,6 +41,13 @@ const EmployeeProfile = () => {
   const [postalCode, setPostalCode] = useState('');
   const [country, setCountry] = useState('');
 
+  // Tier 2 / new Tier 1 fields
+  const [primaryLanguage, setPrimaryLanguage] = useState('');
+  const [bio, setBio] = useState('');
+  const [availability, setAvailability] = useState('');
+  const [willingToTravel, setWillingToTravel] = useState(null);
+  const [isEditingEnhanced, setIsEditingEnhanced] = useState(false);
+
   // Edit mode toggles
   const [isEditingContact, setIsEditingContact] = useState(false);
   const [isEditingAddress, setIsEditingAddress] = useState(false);
@@ -73,17 +80,17 @@ const EmployeeProfile = () => {
     'Saudi Arabia', 'South Africa', 'Egypt', 'Nigeria', 'Kenya'
   ];
 
-  const usStates = [
-    'Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California',
-    'Colorado', 'Connecticut','District of Columbia', 'Delaware', 'Florida', 'Georgia',
-    'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa',
-    'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland',
-    'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri',
-    'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey',
-    'New Mexico', 'New York', 'North Carolina', 'North Dakota', 'Ohio',
-    'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina',
-    'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont',
-    'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
+  const languages = [
+    'English', 'Spanish', 'French', 'Arabic', 'Hindi', 'Bengali', 'Portuguese',
+    'Russian', 'Urdu', 'Indonesian', 'German', 'Japanese', 'Swahili', 'Marathi',
+    'Telugu', 'Chinese (Mandarin)', 'Chinese (Cantonese)', 'Turkish', 'Vietnamese',
+    'Polish', 'Italian', 'Tagalog', 'Hausa', 'Amharic', 'Yoruba', 'Somali',
+    'Burmese', 'Thai', 'Nepali', 'Khmer', 'Other'
+  ];
+
+  const availabilityOptions = [
+    'Full-time', 'Part-time', 'Weekdays only', 'Weekends only',
+    'Flexible', 'Contract / Project-based', 'Seasonal'
   ];
 
   // Skills state
@@ -135,6 +142,12 @@ const EmployeeProfile = () => {
         setStateRegion(data.state || '');
         setPostalCode(data.zip_code || '');
         setCountry(data.country || '');
+
+        // Load new profile fields
+        setPrimaryLanguage(data.primary_language || '');
+        setBio(data.bio || '');
+        setAvailability(data.availability || '');
+        setWillingToTravel(data.willing_to_travel !== undefined && data.willing_to_travel !== null ? data.willing_to_travel : null);
 
         // Load skills from DB
         if (data.skills) {
@@ -237,7 +250,8 @@ const EmployeeProfile = () => {
       last_name: lastName,
       email: email,
       phone_number: phone,
-      country_code: countryCode
+      country_code: countryCode,
+      primary_language: primaryLanguage
     };
     await saveToAPI(contactData, 'Contact information saved');
     setIsEditingContact(false);
@@ -354,6 +368,31 @@ const EmployeeProfile = () => {
     await saveToAPI({ work_experience: cleaned }, 'Work experience saved');
   };
 
+  // Profile completeness (0–100)
+  // Tier 1 (60 pts): name, address, city, country, primary language
+  // Tier 2 (40 pts): bio, availability, willing_to_travel answered, skills, work experience
+  const completeness = useMemo(() => {
+    const t1 = [firstName, lastName, address1, city, country, primaryLanguage].filter(v => v?.trim()).length;
+    const t2 = [
+      bio?.trim(),
+      availability,
+      willingToTravel !== null,
+      skills.length > 0,
+      experiences.some(e => e.title?.trim()),
+    ].filter(Boolean).length;
+    return Math.round((t1 / 6) * 60 + (t2 / 5) * 40);
+  }, [firstName, lastName, address1, city, country, primaryLanguage, bio, availability, willingToTravel, skills, experiences]);
+
+  const handleSaveEnhanced = async () => {
+    await saveToAPI({
+      primary_language: primaryLanguage,
+      bio,
+      availability,
+      willing_to_travel: willingToTravel,
+    }, 'Profile updated');
+    setIsEditingEnhanced(false);
+  };
+
   if (loading) {
     return (
       <div className="min-h-screen bg-white">
@@ -375,16 +414,34 @@ const EmployeeProfile = () => {
       <EmployeeNavbar />
 
       <div className="pt-40 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
-        {/* Header: Avatar + Name */}
-        <div className="flex items-center gap-6 mb-8">
+        {/* Header: Avatar + Name + Completeness */}
+        <div className="flex items-center gap-6 mb-4">
           <img
             src={img}
             alt={fullName}
             className="w-20 h-20 sm:w-24 sm:h-24 rounded-full object-cover"
           />
-          <div>
+          <div className="flex-1">
             <h1 className="text-2xl sm:text-3xl font-bold text-[#0D3B66]">{fullName}</h1>
-            <p className="text-gray-500">Employee</p>
+            <p className="text-gray-500 mb-3">Employee</p>
+            <div className="flex items-center gap-3">
+              <div className="flex-1 bg-gray-200 rounded-full h-2 overflow-hidden">
+                <div
+                  className={`h-2 rounded-full transition-all duration-500 ${
+                    completeness >= 80 ? 'bg-emerald-500' : completeness >= 50 ? 'bg-[#EE964B]' : 'bg-red-400'
+                  }`}
+                  style={{ width: `${completeness}%` }}
+                />
+              </div>
+              <span className="text-sm font-semibold text-gray-600 whitespace-nowrap">{completeness}% complete</span>
+            </div>
+            {completeness < 100 && (
+              <p className="text-xs text-gray-400 mt-1">
+                {completeness < 60
+                  ? 'Complete your required fields to be visible to employers'
+                  : 'Add more details to stand out to employers'}
+              </p>
+            )}
           </div>
         </div>
 
@@ -476,6 +533,16 @@ const EmployeeProfile = () => {
                   </div>
                 )}
 
+                <label className="block text-sm text-gray-600 mb-1 mt-2">Primary Language</label>
+                <select
+                  value={primaryLanguage}
+                  onChange={(e) => setPrimaryLanguage(e.target.value)}
+                  className="w-full mb-4 px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#EE964B]"
+                >
+                  <option value="">Select language</option>
+                  {languages.map(l => <option key={l} value={l}>{l}</option>)}
+                </select>
+
                 <div className="flex gap-3">
                   <button
                     onClick={handleSaveContact}
@@ -522,6 +589,12 @@ const EmployeeProfile = () => {
                     )}
                   </div>
                 </div>
+                {primaryLanguage && (
+                  <div>
+                    <div className="text-sm text-gray-500">Primary Language</div>
+                    <div className="text-gray-800">{primaryLanguage}</div>
+                  </div>
+                )}
               </div>
             )}
           </div>
@@ -572,23 +645,20 @@ const EmployeeProfile = () => {
                     />
                   </div>
                   <div>
-                    <label className="block text-sm text-gray-600 mb-1">State / Region</label>
-                    <select
+                    <label className="block text-sm text-gray-600 mb-1">State / Province / Region <span className="text-gray-400">(optional)</span></label>
+                    <input
+                      type="text"
                       value={stateRegion}
                       onChange={(e) => setStateRegion(e.target.value)}
                       className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#EE964B]"
-                    >
-                      <option value="">Select State</option>
-                      {usStates.map((state) => (
-                        <option key={state} value={state}>{state}</option>
-                      ))}
-                    </select>
+                      placeholder="State, province, or region"
+                    />
                   </div>
                 </div>
 
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
                   <div>
-                    <label className="block text-sm text-gray-600 mb-1">Postal Code</label>
+                    <label className="block text-sm text-gray-600 mb-1">Postal Code <span className="text-gray-400">(optional)</span></label>
                     <input
                       type="text"
                       value={postalCode}
@@ -884,6 +954,100 @@ const EmployeeProfile = () => {
 
           {skills.length === 0 && (
             <p className="mt-3 text-gray-400 text-sm">No skills selected yet. Search or expand a category above, or add your own.</p>
+          )}
+        </div>
+
+        {/* Enhance Your Profile */}
+        <div className="mt-6 bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-lg font-semibold text-[#0D3B66]">Enhance Your Profile</h2>
+              <p className="text-sm text-gray-500 mt-0.5">Optional details that help employers find the right fit</p>
+            </div>
+            <button
+              type="button"
+              aria-label={isEditingEnhanced ? 'Finish editing profile' : 'Edit profile details'}
+              onClick={() => setIsEditingEnhanced((v) => !v)}
+              className="text-[#0D3B66] hover:text-[#EE964B] transition-colors"
+            >
+              <PencilIcon />
+            </button>
+          </div>
+
+          {isEditingEnhanced ? (
+            <>
+              <label className="block text-sm text-gray-600 mb-1">Availability</label>
+              <select
+                value={availability}
+                onChange={(e) => setAvailability(e.target.value)}
+                className="w-full mb-4 px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#EE964B]"
+              >
+                <option value="">Select availability</option>
+                {availabilityOptions.map(o => <option key={o} value={o}>{o}</option>)}
+              </select>
+
+              <label className="block text-sm text-gray-600 mb-1">Bio</label>
+              <textarea
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+                rows={4}
+                maxLength={500}
+                className="w-full mb-1 px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#EE964B] resize-none"
+                placeholder="A brief introduction about yourself, your experience, and what you're looking for..."
+              />
+              <p className="text-xs text-gray-400 mb-4 text-right">{bio.length}/500</p>
+
+              <label className="block text-sm text-gray-600 mb-2">Open to Travel?</label>
+              <div className="flex gap-3 mb-6">
+                {[{ label: 'Yes', value: true }, { label: 'No', value: false }, { label: 'Prefer not to say', value: null }].map(opt => (
+                  <button
+                    key={String(opt.value)}
+                    type="button"
+                    onClick={() => setWillingToTravel(opt.value)}
+                    className={`px-4 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                      willingToTravel === opt.value
+                        ? 'bg-[#0D3B66] text-white border-[#0D3B66]'
+                        : 'bg-white text-gray-700 border-gray-300 hover:border-[#EE964B]'
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+
+              <div className="flex gap-3">
+                <button
+                  onClick={handleSaveEnhanced}
+                  disabled={isSaving}
+                  className="flex-1 bg-[#EE964B] text-white py-2 rounded-lg font-semibold hover:bg-[#d97b33] transition-all disabled:opacity-60"
+                >
+                  {isSaving ? 'Saving...' : 'Save'}
+                </button>
+                <button
+                  onClick={() => setIsEditingEnhanced(false)}
+                  className="flex-1 bg-gray-200 text-[#0D3B66] py-2 rounded-lg font-semibold hover:bg-gray-300 transition-all"
+                >
+                  Cancel
+                </button>
+              </div>
+            </>
+          ) : (
+            <div className="space-y-3">
+              <div>
+                <div className="text-sm text-gray-500">Availability</div>
+                <div className="text-gray-800">{availability || '—'}</div>
+              </div>
+              <div>
+                <div className="text-sm text-gray-500">Bio</div>
+                <div className="text-gray-800 whitespace-pre-wrap">{bio || '—'}</div>
+              </div>
+              <div>
+                <div className="text-sm text-gray-500">Open to Travel</div>
+                <div className="text-gray-800">
+                  {willingToTravel === null ? '—' : willingToTravel ? 'Yes' : 'No'}
+                </div>
+              </div>
+            </div>
           )}
         </div>
 

--- a/client/src/pages/UserProfile.jsx
+++ b/client/src/pages/UserProfile.jsx
@@ -28,11 +28,12 @@ const UserProfile = () => {
   const [formData, setFormData] = useState({
     firstName: '',
     lastName: '',
+    primaryLanguage: '',
     streetAddress: '',
     streetAddress2: '',
     country: '',
-    zipCode: '',
-    state: '',
+    postalCode: '',
+    stateRegion: '',
     city: '',
     // Company fields for employers
     companyName: '',
@@ -44,6 +45,14 @@ const UserProfile = () => {
   const [loading, setLoading] = useState(false);
   const [errors, setErrors] = useState({});
   const [submitted, setSubmitted] = useState(false);
+
+  const languages = [
+    'English', 'Spanish', 'French', 'Arabic', 'Hindi', 'Bengali', 'Portuguese',
+    'Russian', 'Urdu', 'Indonesian', 'German', 'Japanese', 'Swahili', 'Marathi',
+    'Telugu', 'Chinese (Mandarin)', 'Chinese (Cantonese)', 'Turkish', 'Vietnamese',
+    'Polish', 'Italian', 'Tagalog', 'Hausa', 'Amharic', 'Yoruba', 'Somali',
+    'Burmese', 'Thai', 'Nepali', 'Khmer', 'Other'
+  ];
 
   const countries = [
     'United States', 'Canada', 'United Kingdom', 'India', 'Australia',
@@ -153,10 +162,9 @@ const UserProfile = () => {
 
     if (!formData.firstName.trim()) newErrors.firstName = 'First name is required';
     if (!formData.lastName.trim()) newErrors.lastName = 'Last name is required';
+    if (!formData.primaryLanguage) newErrors.primaryLanguage = 'Primary language is required';
     if (!formData.streetAddress.trim()) newErrors.streetAddress = 'Street address is required';
     if (!formData.country.trim()) newErrors.country = 'Country is required';
-    if (!formData.zipCode.trim()) newErrors.zipCode = 'Zip code is required';
-    if (!formData.state.trim()) newErrors.state = 'State/Province is required';
     if (!formData.city.trim()) newErrors.city = 'City is required';
 
     // Employer-specific validation
@@ -189,13 +197,14 @@ const UserProfile = () => {
       const payload = {
         first_name: formData.firstName,
         last_name: formData.lastName,
+        primary_language: formData.primaryLanguage,
         email: currentEmail,
         phone_number: currentPhone,
         street_address: formData.streetAddress,
         street_address2: formData.streetAddress2,
         country: formData.country,
-        zip_code: formData.zipCode,
-        state: formData.state,
+        zip_code: formData.postalCode,
+        state: formData.stateRegion,
         city: formData.city,
         wallet_address: walletAddress,
       };
@@ -285,6 +294,22 @@ const UserProfile = () => {
               />
               {errors.lastName && <p className="text-red-500 text-sm mt-1">{errors.lastName}</p>}
             </div>
+          </div>
+
+          {/* Primary Language — required for all roles */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Primary Language *</label>
+            <select
+              value={formData.primaryLanguage}
+              onChange={(e) => handleInputChange('primaryLanguage', e.target.value)}
+              className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${errors.primaryLanguage ? 'border-red-500' : 'border-gray-300'}`}
+            >
+              <option value="">Select your primary language</option>
+              {languages.map(lang => (
+                <option key={lang} value={lang}>{lang}</option>
+              ))}
+            </select>
+            {errors.primaryLanguage && <p className="text-red-500 text-sm mt-1">{errors.primaryLanguage}</p>}
           </div>
 
           {/* Row 2: Email */}
@@ -381,22 +406,18 @@ const UserProfile = () => {
               {errors.city && <p className="text-red-500 text-sm mt-1">{errors.city}</p>}
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">State/Province *</label>
-              <select
-                value={formData.state}
-                onChange={(e) => handleInputChange('state', e.target.value)}
-                className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${errors.state ? 'border-red-500' : 'border-gray-300'}`}
-              >
-                <option value="">Select your state</option>
-                {usStates.map(state => (
-                  <option key={state} value={state}>{state}</option>
-                ))}
-              </select>
-              {errors.state && <p className="text-red-500 text-sm mt-1">{errors.state}</p>}
+              <label className="block text-sm font-medium text-gray-700 mb-1">State / Province / Region</label>
+              <input
+                type="text"
+                value={formData.stateRegion}
+                onChange={(e) => handleInputChange('stateRegion', e.target.value)}
+                className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 border-gray-300"
+                placeholder="State, province, or region (optional)"
+              />
             </div>
           </div>
 
-          {/* Row 6: Country & Zip */}
+          {/* Row 6: Country & Postal Code */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Country *</label>
@@ -413,15 +434,14 @@ const UserProfile = () => {
               {errors.country && <p className="text-red-500 text-sm mt-1">{errors.country}</p>}
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Zip Code *</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Postal Code</label>
               <input
                 type="text"
-                value={formData.zipCode}
-                onChange={(e) => handleInputChange('zipCode', e.target.value)}
-                className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${errors.zipCode ? 'border-red-500' : 'border-gray-300'}`}
-                placeholder="Enter zip code"
+                value={formData.postalCode}
+                onChange={(e) => handleInputChange('postalCode', e.target.value)}
+                className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 border-gray-300"
+                placeholder="Postal code (optional)"
               />
-              {errors.zipCode && <p className="text-red-500 text-sm mt-1">{errors.zipCode}</p>}
             </div>
           </div>
 

--- a/notes/v0.2.0-milestone-plan.md
+++ b/notes/v0.2.0-milestone-plan.md
@@ -112,17 +112,32 @@ Workers should be able to view the exact terms they signed. Currently the UI use
 **Labels:** `enhancement`, `backend`, `frontend`
 **Effort:** ~4–6 hrs
 
-Expand the worker profile with a tiered approach. Tier 1 (required at onboarding), Tier 2 (prompted, optional), Tier 3 (fully optional).
+Expand the worker profile with a tiered approach. Tier 1 (required at onboarding), Tier 2 (optional, surfaced on profile page with completeness nudge).
+
+**Deferred to v0.4.0 (#94):** education, certifications/licences, photo upload — not relevant for current blue-collar/wage-protection use case.
+
+**Tier 1 — Required at onboarding (keep existing, two fixes, one addition):**
+- Keep required: first name, last name, street address, city, country
+- Make optional: state/province, postal code (not universal internationally)
+- Rename: "Postal code" (not "Zip code"), "State / Province / Region" (not "State")
+- Add as required: **primary language** (new — needed by employers for legal/communication)
+
+**Tier 2 — Optional fields on `EmployeeProfile` page:**
+- Bio, availability, willing to travel (new fields)
+- Skills, work experience (already exist — surface better in "Enhance your profile" section)
 
 **Tasks:**
 1. **DB migration:** Add `primary_language VARCHAR(50)`, `availability VARCHAR(50)`, `bio TEXT`, `willing_to_travel BOOLEAN` to `employee` table.
-   - **Migration:** `017-employee-profile-fields.sql` (check if this overlaps with migration 014)
-2. **Simplify onboarding (`UserProfile`):** Move street address to optional (Tier 3). Require: first name, last name, city, country, primary language.
+2. **Update onboarding (`UserProfile`):**
+   - Add primary language as required field
+   - Make state/province and postal code optional
+   - Rename labels to "Postal code" and "State / Province / Region"
 3. **Profile completeness indicator:**
-   - Calculate score from filled Tier 1 + Tier 2 fields.
-   - Show progress bar on `EmployeeProfile` page.
-   - Optionally surface score to employers on application review.
-4. **Update `EmployeeProfile` page:** Add Tier 2 fields in an "Enhance your profile" section (bio, availability, willing to travel, skills, work experience already exist).
+   - Calculate score from filled Tier 1 + Tier 2 fields
+   - Show progress bar on `EmployeeProfile` page
+   - Single nudge: "Your profile is X% complete — add these fields to stand out" (not scattered prompts)
+   - Optionally surface score to employers on application review (#81)
+4. **Update `EmployeeProfile` page:** Add Tier 2 fields in an "Enhance your profile" section.
 
 ---
 

--- a/server/migrations/021-add-employee-profile-tier2.sql
+++ b/server/migrations/021-add-employee-profile-tier2.sql
@@ -1,0 +1,14 @@
+-- Add Tier 2 worker profile fields
+-- primary_language: required at onboarding going forward (NULL for existing records)
+-- availability, bio, willing_to_travel: optional Tier 2 fields surfaced on profile page
+
+ALTER TABLE public.employee
+  ADD COLUMN IF NOT EXISTS primary_language VARCHAR(50) NULL,
+  ADD COLUMN IF NOT EXISTS availability     VARCHAR(50) NULL,
+  ADD COLUMN IF NOT EXISTS bio              TEXT        NULL,
+  ADD COLUMN IF NOT EXISTS willing_to_travel BOOLEAN    NULL;
+
+COMMENT ON COLUMN public.employee.primary_language  IS 'Primary spoken language — required at onboarding for employer communication/legal purposes';
+COMMENT ON COLUMN public.employee.availability      IS 'Work availability preference, e.g. Full-time, Part-time, Seasonal';
+COMMENT ON COLUMN public.employee.bio               IS 'Short worker bio / introduction (optional Tier 2 field)';
+COMMENT ON COLUMN public.employee.willing_to_travel IS 'Whether worker is open to travel. NULL = not answered, true/false = answered';

--- a/server/models/Employee.js
+++ b/server/models/Employee.js
@@ -61,6 +61,22 @@ const Employee = sequelize.define('Employee', {
   work_experience: {
     type: DataTypes.JSONB,
     allowNull: true
+  },
+  primary_language: {
+    type: DataTypes.STRING(50),
+    allowNull: true
+  },
+  availability: {
+    type: DataTypes.STRING(50),
+    allowNull: true
+  },
+  bio: {
+    type: DataTypes.TEXT,
+    allowNull: true
+  },
+  willing_to_travel: {
+    type: DataTypes.BOOLEAN,
+    allowNull: true
   }
 }, {
   tableName: 'employee',

--- a/server/server.js
+++ b/server/server.js
@@ -146,7 +146,8 @@ async function runMigrationsOnStartup() {
       '017-allow-repeat-contracts-per-worker.sql',
       '018-fix-email-wallet-constraints.sql',
       '019-add-contract-snapshot.sql',
-      '020-add-snapshot-to-job-applications.sql'
+      '020-add-snapshot-to-job-applications.sql',
+      '021-add-employee-profile-tier2.sql'
     ];
 
     for (const file of migrationFiles) {


### PR DESCRIPTION
## Summary
- **Migration 021**: adds `primary_language`, `availability`, `bio`, `willing_to_travel` to `employee` table (all NULL-safe, idempotent)
- **Onboarding (UserProfile)**: `primary_language` now required; `state`/`postal_code` made optional with international-friendly labels; state field changed from US-only dropdown to free text
- **EmployeeProfile**: profile completeness progress bar (Tier 1 required fields = 60 pts, Tier 2 optional = 40 pts); primary language in contact panel; "Enhance Your Profile" panel with bio, availability, and open-to-travel toggle

Closes #50

## Test plan
- [ ] Create a new employee account — confirm primary language is required, state/postal are optional
- [ ] Go to `/employee-profile` — confirm completeness bar reflects filled fields
- [ ] Edit contact panel — change primary language, save, confirm it persists and shows in view mode
- [ ] Edit address panel — confirm State / Province / Region is free text (not US dropdown)
- [ ] Open "Enhance Your Profile" — set bio, availability, willing to travel, save, confirm values persist
- [ ] Verify `willing_to_travel = null` (not answered) is distinct from `false` in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)