### PR TITLE
fix: compliance hub follow-on — date filters, stale routes, role persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,5 +127,8 @@ resolving
 conflict-*
 *.orig
 
+# docs
+docs/ip-audit
+
 # Local notes (now tracked for backup)
 # notes/

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { Routes, Route, Navigate, useNavigate, useLocation } from "react-router-dom";
+import { Routes, Route, useNavigate, useLocation } from "react-router-dom";
 import { PrivyProvider } from "@privy-io/react-auth";
 import { SmartWalletsProvider } from "@privy-io/react-auth/smart-wallets";
 import { baseSepolia } from "viem/chains";
@@ -203,7 +203,7 @@ const AppContent = () => {
                   profileExists = true;
                 }
               }
-            } catch (err) {
+            } catch {
               // Ignore 404s (expected if profile doesn't exist)
             }
           }
@@ -228,7 +228,7 @@ const AppContent = () => {
                   profileExists = true;
                 }
               }
-            } catch (err) { /* 404 expected */ }
+            } catch { /* 404 expected */ }
           }
 
           // Check if user has both roles (for role switcher UI)
@@ -240,7 +240,7 @@ const AppContent = () => {
               if (response?.data) {
                 hasOtherRole = true;
               }
-            } catch (err) {
+            } catch {
               // Ignore 404s
             }
           }
@@ -386,9 +386,6 @@ const App = () => {
             </Route>
 
             {/* Employer Routes */}
-            <Route path="/employerDashboard" element={<Navigate to="/contract-factory" replace />} />
-            {/* Redirect old job posting route to Recruitment Hub */}
-            <Route path="/job" element={<Navigate to="/contract-factory" replace />} />
             <Route element={<EmployerLayout />}>
               <Route path="/employer-profile" element={
                 <ProtectedRoute requiredRole="employer">

--- a/client/src/EmployerPages/ComplianceHub/CompletedContractsTab.jsx
+++ b/client/src/EmployerPages/ComplianceHub/CompletedContractsTab.jsx
@@ -18,6 +18,9 @@ const CompletedContractsTab = () => {
   const { employerId } = useEmployer();
   const [contracts, setContracts] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
 
   useEffect(() => {
     const fetchContracts = async () => {
@@ -37,6 +40,18 @@ const CompletedContractsTab = () => {
     };
     fetchContracts();
   }, [employerId]);
+
+  const filtered = contracts.filter((c) => {
+    const term = search.toLowerCase();
+    if (term) {
+      const title = c.jobPosting?.title || "";
+      const worker = `${c.employee?.first_name || ""} ${c.employee?.last_name || ""}`.trim();
+      if (!title.toLowerCase().includes(term) && !worker.toLowerCase().includes(term)) return false;
+    }
+    if (startDate && new Date(c.updated_at) < new Date(startDate)) return false;
+    if (endDate && new Date(c.updated_at) > new Date(endDate + "T23:59:59")) return false;
+    return true;
+  });
 
   if (loading) {
     return (
@@ -59,7 +74,43 @@ const CompletedContractsTab = () => {
 
   return (
     <div className="space-y-4">
-      {contracts.map((contract) => {
+      {/* Filters */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <input
+          type="text"
+          placeholder="Search by job title or worker name..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="flex-1 p-3 text-sm rounded-xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-[#EE964B]"
+        />
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          className="p-3 text-sm rounded-xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-[#EE964B]"
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          className="p-3 text-sm rounded-xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-[#EE964B]"
+        />
+        {(search || startDate || endDate) && (
+          <button
+            onClick={() => { setSearch(""); setStartDate(""); setEndDate(""); }}
+            className="px-3 py-2 text-sm text-gray-500 hover:text-gray-700 border border-gray-200 rounded-xl hover:bg-gray-50 transition-colors"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-16">
+          <CheckCircle className="h-12 w-12 text-gray-300 mx-auto mb-3" />
+          <p className="text-sm text-gray-500">No contracts match your filters.</p>
+        </div>
+      ) : filtered.map((contract) => {
         const worker = `${contract.employee?.first_name || ""} ${contract.employee?.last_name || ""}`.trim() || "—";
         const isMock = contract.contract_address?.startsWith("0x000000");
 
@@ -124,5 +175,6 @@ const CompletedContractsTab = () => {
     </div>
   );
 };
+
 
 export default CompletedContractsTab;

--- a/client/src/EmployerPages/ComplianceHub/DisputesTab.jsx
+++ b/client/src/EmployerPages/ComplianceHub/DisputesTab.jsx
@@ -55,6 +55,8 @@ const DisputesTab = () => {
   const [error, setError] = useState("");
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState("all");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
 
   useEffect(() => {
     const fetchDisputes = async () => {
@@ -79,6 +81,8 @@ const DisputesTab = () => {
   const filtered = disputes.filter((d) => {
     if (filter === "pending" && d.resolved_at) return false;
     if (filter === "resolved" && !d.resolved_at) return false;
+    if (startDate && new Date(d.raised_at) < new Date(startDate)) return false;
+    if (endDate && new Date(d.raised_at) > new Date(endDate + "T23:59:59")) return false;
     const term = search.toLowerCase();
     if (!term) return true;
     const title = d.deployedContract?.jobPosting?.title || "";
@@ -133,6 +137,26 @@ const DisputesTab = () => {
           <option value="pending">Pending</option>
           <option value="resolved">Resolved</option>
         </select>
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          className="p-3 text-sm rounded-xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-[#EE964B]"
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          className="p-3 text-sm rounded-xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-[#EE964B]"
+        />
+        {(startDate || endDate) && (
+          <button
+            onClick={() => { setStartDate(""); setEndDate(""); }}
+            className="px-3 py-2 text-sm text-gray-500 hover:text-gray-700 border border-gray-200 rounded-xl hover:bg-gray-50 transition-colors"
+          >
+            Clear
+          </button>
+        )}
       </div>
 
       {loading ? (

--- a/client/src/components/EmployerNavbar.jsx
+++ b/client/src/components/EmployerNavbar.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
-import { NavLink, Link, useNavigate } from "react-router-dom";
+import { NavLink, Link } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
 import logo from "../assets/Android.png";
 import SmartWalletInfo from "./SmartWalletInfo";
@@ -14,7 +14,6 @@ const EmployerNavbar = () => {
 
   const { user, smartWalletAddress } = useAuth();
   const mobileMenuRef = useRef(null);
-  const navigate = useNavigate();
 
   // Close dropdowns when clicking outside
   useEffect(() => {
@@ -52,11 +51,6 @@ const EmployerNavbar = () => {
     }
   }, [smartWalletAddress, user?.email?.address]);
 
-  const handleHomeClick = () => {
-    navigate('/employerDashboard');
-    setIsMobileMenuOpen(false);
-  };
-
   const handleNavClick = () => {
     setIsMobileMenuOpen(false);
   };
@@ -68,7 +62,7 @@ const EmployerNavbar = () => {
         <div className="max-w-7xl w-full mx-auto flex items-center justify-between px-4 sm:px-8 py-3">
         {/* Enhanced Brand Name */}
         <Link
-          to="/employerDashboard"
+          to="/contract-factory"
           className="flex items-center gap-1 text-2xl sm:text-3xl font-bold tracking-wide">
           <img
             src={logo}
@@ -82,17 +76,6 @@ const EmployerNavbar = () => {
 
         {/* Desktop Navigation */}
         <div className="hidden lg:flex items-center gap-6 text-md">
-          <NavLink
-            to="/employerDashboard"
-            className={({ isActive }) =>
-              `transition-all font-medium flex items-center gap-2 px-3 py-2 rounded ${
-                isActive ? "text-[#EE964B] font-semibold bg-[#1a4a7a]" : "text-white hover:text-[#F4D35E] hover:bg-[#1a4a7a]"
-              }`
-            }>
-            <span>🏠</span>
-            Home
-          </NavLink>
-
           <NavLink
             to="/contract-factory"
             className={({ isActive }) =>
@@ -215,17 +198,6 @@ const EmployerNavbar = () => {
 
             {/* Navigation Links */}
             <div className="space-y-3">
-              <NavLink
-                to="/employerDashboard"
-                onClick={handleNavClick}
-                className={({ isActive }) =>
-                  `block w-full text-left transition-all font-medium py-2 px-3 rounded ${
-                    isActive ? "text-[#EE964B] font-semibold bg-[#1a4a7a]" : "text-white hover:text-[#F4D35E] hover:bg-[#1a4a7a]"
-                  }`
-                }>
-                🏠 Home
-              </NavLink>
-
               <NavLink
                 to="/contract-factory"
                 onClick={handleNavClick}

--- a/client/src/pages/EmployerLandingPage.jsx
+++ b/client/src/pages/EmployerLandingPage.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
 import PublicEmployerNavbar from "../components/PublicEmployerNavbar";
@@ -12,6 +12,13 @@ const EmployerLandingPage = () => {
   const navigate = useNavigate();
   const { login } = useAuth();
   // Note: Redirect logic handled by App.jsx, same as employee landing page
+
+  // Set role on mount so returning authenticated users get the correct intendedRole
+  // in the App.jsx profile check (not just users who click the login button)
+  useEffect(() => {
+    localStorage.setItem('pendingRole', 'employer');
+    localStorage.setItem('userRole', 'employer');
+  }, []);
 
   const handleEmployerLogin = () => {
     localStorage.setItem('pendingRole', 'employer');


### PR DESCRIPTION
## Summary
- Add date range filters to Completed Contracts and Disputes tabs in Compliance Hub
- Remove stale `/employerDashboard` and `/job` redirect routes
- Remove Home nav link pointing to `/employerDashboard` in EmployerNavbar
- Fix role persistence on mount in EmployerLandingPage for returning authenticated users
- Exclude `docs/ip-audit` from git

## Test plan
- [ ] Compliance Hub → Completed Contracts: date range filter shows/clears correctly
- [ ] Compliance Hub → Disputes: date range filter works alongside existing status filter
- [ ] Navigating to `/employerDashboard` no longer redirects (404 or just falls through)
- [ ] Employer logo/brand link goes to `/contract-factory`
- [ ] Returning authenticated employer user lands on employer dashboard correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)