### PR TITLE
feat(#54): QRCodeOracle contract, on-chain registration, and backend wiring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,6 +157,12 @@ jobs:
 
         # Admin Configuration
         ADMIN_EMAILS=${{ vars.ADMIN_EMAILS }}
+
+        # QR Oracle
+        QR_ORACLE_ADDRESS=${{ vars.QR_ORACLE_ADDRESS }}
+        ORACLE_BACKEND_ADDRESS=${{ vars.ORACLE_BACKEND_ADDRESS }}
+        ORACLE_PRIVATE_KEY=${{ secrets.ORACLE_PRIVATE_KEY }}
+        BASE_RPC_URL=${{ vars.BASE_RPC_URL }}
         SERVER_ENV_EOF
 
         # Remove leading whitespace from heredoc indentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,10 @@ docker compose logs -f [backend|frontend]              # View logs
 docker compose -f docker-compose.nginx.yml up -d --build
 ```
 
+**Important**: After adding new npm packages, the Docker container must be rebuilt — `docker compose restart` does NOT re-run `npm install`. The anonymous `node_modules` volume persists across regular rebuilds, so new packages require: `docker compose down -v && docker compose up -d --build`. (Warning: `-v` also removes the postgres data volume — only use in dev.)
+
+**Workflow rule**: Test changes locally in Docker before committing, pushing to main, creating pull requests, or merging pull requests.
+
 ### Database
 ```bash
 # Migrations run automatically on server startup via server.js

--- a/client/src/EmployerPages/ContractFactory/AwaitingDeploymentTab.jsx
+++ b/client/src/EmployerPages/ContractFactory/AwaitingDeploymentTab.jsx
@@ -14,7 +14,7 @@ const USDC_DECIMALS = 6;
 
 // Oracle types currently registered on-chain. Unregistered types are filtered out
 // so the factory doesn't revert. Expand this list as new oracles are deployed.
-const REGISTERED_ORACLE_TYPES = ["manual"];
+const REGISTERED_ORACLE_TYPES = ["manual", "qr"];
 
 /**
  * Parse the comma-separated selected_oracles string from the DB into

--- a/contracts/scripts/deployQRCodeOracle.js
+++ b/contracts/scripts/deployQRCodeOracle.js
@@ -1,0 +1,61 @@
+/**
+ * Deployment script for QRCodeOracle
+ *
+ * Usage:
+ *   cd contracts
+ *   npx hardhat run scripts/deployQRCodeOracle.js --network baseSepolia
+ *
+ * Requires in contracts/.env:
+ *   PRIVATE_KEY=<deployer private key, without 0x>
+ *   BACKEND_ADDRESS=<server oracle wallet address>
+ */
+
+const hre = require("hardhat");
+
+async function main() {
+  const network = hre.network.name;
+  console.log(`Deploying QRCodeOracle to network: ${network}`);
+
+  const backendAddress = process.env.BACKEND_ADDRESS;
+  if (!backendAddress) {
+    throw new Error("BACKEND_ADDRESS is required (the server wallet that will call recordVerification())");
+  }
+  console.log(`Backend address: ${backendAddress}`);
+
+  const [deployer] = await hre.ethers.getSigners();
+  console.log(`Deploying with account: ${deployer.address}`);
+
+  const balance = await hre.ethers.provider.getBalance(deployer.address);
+  console.log(`Account balance: ${hre.ethers.formatEther(balance)} ETH`);
+
+  console.log("\nDeploying QRCodeOracle...");
+  const QRCodeOracle = await hre.ethers.getContractFactory("QRCodeOracle");
+  const oracle = await QRCodeOracle.deploy(backendAddress);
+  await oracle.waitForDeployment();
+
+  const oracleAddress = await oracle.getAddress();
+  console.log(`QRCodeOracle deployed to: ${oracleAddress}`);
+
+  const registeredBackend = await oracle.backend();
+  console.log(`Verified backend address: ${registeredBackend}`);
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`QRCodeOracle deployed to: ${oracleAddress}`);
+  console.log(`Backend:                  ${backendAddress}`);
+  console.log(`${"=".repeat(60)}`);
+
+  console.log("\nNext steps:");
+  console.log(`1. Register via admin UI: paste ${oracleAddress} at /admin/deploy-factory`);
+  console.log(`2. Add to server/.env: QR_ORACLE_ADDRESS=${oracleAddress}`);
+  console.log(`3. Verify contract: npx hardhat verify --network ${network} ${oracleAddress} ${backendAddress}`);
+}
+
+main()
+  .then(() => {
+    console.log("\nDeployment complete!");
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error("Deployment failed:", error);
+    process.exit(1);
+  });

--- a/contracts/src/oracles/QRCodeOracle.sol
+++ b/contracts/src/oracles/QRCodeOracle.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.20;
+
+import "../interfaces/IWorkOracle.sol";
+
+/**
+ * @title QRCodeOracle
+ * @dev QR code attendance oracle — the backend server wallet calls
+ *      recordVerification() after a valid worker QR scan is validated.
+ *
+ * This is a singleton contract: one QRCodeOracle serves all WorkContracts.
+ * Only the trusted backend address (set at deploy time) can record verifications.
+ *
+ * In v0.2.0, the employer still calls approveAndPay() manually — QR verification
+ * is a prerequisite gate, not an auto-release trigger. Auto-release for QR-only
+ * contracts is planned for v0.4.0 (#82).
+ */
+contract QRCodeOracle is IWorkOracle {
+    address public immutable backend;
+
+    mapping(address => bool) private _verified;
+
+    event WorkVerified(address indexed workContract, address indexed recordedBy);
+
+    /**
+     * @param _backend Address of the trusted backend server wallet that may
+     *                 call recordVerification(). Cannot be changed after deploy.
+     */
+    constructor(address _backend) {
+        require(_backend != address(0), "Invalid backend address");
+        backend = _backend;
+    }
+
+    /**
+     * @notice Backend records a successful QR scan verification for a contract.
+     * @param workContract Address of the WorkContract that has been verified
+     */
+    function recordVerification(address workContract) external {
+        require(msg.sender == backend, "Only backend can record verification");
+        require(workContract != address(0), "Invalid contract address");
+        require(!_verified[workContract], "Already verified");
+
+        _verified[workContract] = true;
+
+        emit WorkVerified(workContract, msg.sender);
+    }
+
+    /// @inheritdoc IWorkOracle
+    function isWorkVerified(address workContract) external view override returns (bool) {
+        return _verified[workContract];
+    }
+
+    /// @inheritdoc IWorkOracle
+    function oracleType() external pure override returns (string memory) {
+        return "qr";
+    }
+}

--- a/notes/aws-rds-postgresql-mandatory-minor-upgrade-2026-05.md
+++ b/notes/aws-rds-postgresql-mandatory-minor-upgrade-2026-05.md
@@ -1,0 +1,74 @@
+# AWS RDS PostgreSQL Mandatory Minor Upgrade Notice (May 2026)
+
+## Summary
+AWS sent a health notice indicating one or more RDS PostgreSQL instances in our AWS account are on minor versions that are reaching end of standard support.
+
+Key dates from AWS notice:
+- **May 1, 2026**: Cannot create new RDS instances on the listed old minor versions.
+- **May 31, 2026**: End of standard support for those minor versions.
+- **After May 31, 2026**: AWS will automatically upgrade affected instances during a maintenance window.
+
+AWS target versions mentioned:
+- PostgreSQL 14 -> 14.20 (or higher)
+- PostgreSQL 15 -> 15.15 (or higher)
+- PostgreSQL 16 -> 16.11 (or higher)
+- PostgreSQL 17 -> 17.7 (or higher)
+
+## Does this apply to this repository?
+Short answer: **indirectly yes, directly no**.
+
+- This repository uses PostgreSQL and is designed to run against AWS RDS in production.
+- The application code does **not** pin a specific PostgreSQL *minor* version.
+- Therefore, impact is determined by the **actual RDS instance versions in AWS**, not by source code alone.
+
+Code references:
+- Local dev DB image uses PostgreSQL 15: [`docker-compose.yml`](../docker-compose.yml)
+- Production DB is external via environment variables and RDS-style host config: [`server/config/database.js`](../server/config/database.js), [`server/.env.example`](../server/.env.example)
+
+## What is actually happening
+This is an **infrastructure lifecycle event** from AWS, not a feature or security alert specific to our code.
+
+If we do nothing:
+- AWS will eventually perform a mandatory minor upgrade in a maintenance window.
+- There will be downtime during the upgrade.
+- The timing is constrained by AWS windows rather than our preferred release timing.
+
+## Recommended plan
+1. **Inventory affected DBs**
+   - Open AWS Health Dashboard -> Affected resources.
+   - Record each DB instance, environment (prod/staging/dev), engine version, and maintenance window.
+
+2. **Choose target versions now**
+   - Keep same major version, move to current supported minor target suggested by AWS.
+   - Avoid waiting for forced upgrade windows.
+
+3. **Test in staging first**
+   - Upgrade a staging instance first.
+   - Run application smoke tests: auth, core CRUD flows, contract creation, dispute workflows, reporting endpoints, and migrations.
+
+4. **Prepare production change window**
+   - Snapshot production DB immediately before upgrade.
+   - Confirm rollback/restore steps and access.
+   - Notify stakeholders of planned maintenance.
+
+5. **Execute controlled production upgrade**
+   - Run manual minor upgrade in planned window.
+   - If downtime sensitivity is high, use RDS Blue/Green Deployment to reduce cutover interruption.
+
+6. **Post-upgrade validation**
+   - Verify API health endpoints.
+   - Check error logs and DB connection stability.
+   - Validate critical business flows and background jobs.
+
+## Operational checklist (quick)
+- [ ] AWS Health affected resources exported and tracked
+- [ ] Target version selected for each instance
+- [ ] Staging upgraded and validated
+- [ ] Pre-upgrade snapshot taken
+- [ ] Maintenance comms sent
+- [ ] Production upgraded manually
+- [ ] Post-upgrade smoke tests passed
+- [ ] Monitoring/log review complete
+
+## Notes for this codebase
+Because Sequelize + PostgreSQL usage here is standard (no pinned minor-specific SQL behavior observed in config), compatibility risk is usually low for minor upgrades. The bigger risk is **downtime timing** and **operational readiness**, not code breakage.

--- a/notes/mobile-app-options-auth-research-2026-03-10.md
+++ b/notes/mobile-app-options-auth-research-2026-03-10.md
@@ -1,0 +1,316 @@
+# Mobile App Options And Auth Research
+
+Date: 2026-03-10
+
+## Context
+
+This note summarizes a review of the current LucidLedger codebase and follow-up research on React Native, PWA, Capacitor, Privy auth, `localStorage`, and `HttpOnly` cookies.
+
+The goal was to answer:
+
+- How much work would be involved in making a phone app in React Native?
+- Should that be a new repo or part of the existing project?
+- Would Capacitor or a PWA wrapper fit better?
+- Why might auth have failed in a previous PWA attempt?
+- Is relying on `localStorage` for auth a problem?
+- Would migrating to `HttpOnly` cookies be a reasonable next milestone?
+
+## Codebase Findings
+
+The current frontend is a browser-first React/Vite app, not a shared React codebase designed to target both web and native.
+
+Key signals:
+
+- Web-only entry point and DOM rendering in `client/src/main.jsx`
+- Web routing via `react-router-dom` in `client/src/App.jsx`
+- Tailwind/CSS styling in `client/src/index.css`
+- Heavy use of browser APIs such as `localStorage`, `window`, `document`, and `navigator`
+- Auth and wallet flows built around Privy's web React SDK
+
+Examples:
+
+- `client/src/main.jsx` uses `react-dom/client`, `document.getElementById`, and `BrowserRouter`
+- `client/src/App.jsx` uses `PrivyProvider`, `SmartWalletsProvider`, route-based redirects, and `localStorage`
+- `client/src/hooks/useAuth.js` clears role and pending-action state from `localStorage`
+- `client/src/services/api.js` fetches a Privy access token and sends `Authorization: Bearer ...`
+- `server/middleware/authMiddleware.js` expects bearer tokens from the `Authorization` header
+
+The frontend surface area is non-trivial:
+
+- 71 JS/JSX files under `client/src`
+- Major sections include `components`, `EmployerPages`, `EmployeePages`, `pages`, and `Form`
+
+## React Native Assessment
+
+Conclusion:
+
+- React Native would not be "just a few plugins"
+- React Native would also not be "start from absolute scratch"
+- The realistic description is: a frontend rewrite over an existing backend
+
+What can be reused:
+
+- Most of the backend API and database
+- A good amount of business rules
+- Some API client structure
+- Some blockchain/domain logic, depending on mobile wallet/auth compatibility
+- Smart contract ABIs and chain interaction concepts
+
+What would need major rework:
+
+- Navigation
+- Most UI components and layouts
+- Forms and responsive interactions
+- Browser-only storage and event flows
+- Download/export behavior
+- Browser geolocation and permissions
+- Current Privy web SDK integration
+- Any code assuming `window.ethereum`
+
+Bottom line:
+
+- A true React Native client should generally be a separate mobile frontend
+- For this repo, that likely means a new repo unless there is a deliberate monorepo/shared-package plan
+
+## Repo Recommendation
+
+Recommendation:
+
+- Keep the current repo for web app + backend
+- If building React Native, create a separate repo for the mobile app
+- Optionally move shared utilities into shared packages later
+
+Reason:
+
+- Web and React Native would have different runtimes, navigation, UI primitives, build pipelines, and mobile-native configuration
+- Keeping React Native inside the existing `client/` app as a normal milestone would blur two different frontends
+
+## PWA And Capacitor Assessment
+
+For this codebase, PWA or Capacitor are much more natural extensions of the existing project than React Native.
+
+Why:
+
+- The app is already a web app
+- Existing React, routing, and browser-oriented UI can be kept
+- This can be treated as another delivery target rather than a second frontend product
+
+Tradeoff:
+
+- PWA is the lowest-effort path
+- Capacitor is more work than PWA, but much less work than React Native
+- Capacitor is better if app-store packaging, native permissions, camera/files/geolocation plugins, or push notifications matter
+
+Recommended order:
+
+1. Improve mobile UX in the existing web app
+2. Use PWA if the goal is the fastest installable mobile access
+3. Use Capacitor if app-store distribution and native device integration matter
+4. Revisit React Native only if the web-based mobile approach proves insufficient
+
+## Why Auth Likely Failed In A Previous PWA Attempt
+
+Based on this codebase, auth is the first area where trouble would be expected in a PWA.
+
+Likely causes:
+
+- Auth popup or redirect flow failed or was blocked
+- Session state did not persist reliably on mobile browsers
+- `localStorage`-based role and pending-action logic was lost or became inconsistent
+- Smart wallet creation/linking behaved differently on mobile
+- Any auth flow depending on returning from email/SMS/browser handoff became fragile
+
+Why this repo is especially sensitive:
+
+- `client/src/App.jsx` contains substantial post-login redirect and role detection logic
+- `client/src/hooks/useAuth.js` and many UI flows depend on `localStorage`
+- `client/src/EmployeePages/EmployeeJobsPage.jsx` stores pending actions and uses `window` events
+- Core on-chain flows depend on `smartWalletClient` and `smartWalletAddress`
+
+Important point:
+
+- PWA issues do not automatically mean Capacitor is impossible
+- They do mean auth, deep-link return, persistence, and wallet flow must be treated as the first proof-of-concept
+
+## Capacitor Research Summary
+
+Official Capacitor position:
+
+- Capacitor is intended to be added to an existing modern web app
+- Native projects remain real Xcode/Android Studio projects
+- Capacitor provides native APIs via plugins, but does not eliminate mobile app architecture concerns
+
+What official docs suggest:
+
+- Existing web apps are a valid starting point
+- Use real native configuration where needed
+- Use native/browser plugins and deep-link handling for auth-like flows
+- Use plugin-backed storage instead of relying on WebView `localStorage` for important persistent data
+
+Relevant official docs:
+
+- https://capacitorjs.com/docs
+- https://capacitorjs.com/docs/basics/workflow
+- https://capacitorjs.com/docs/basics/configuring-your-app
+- https://capacitorjs.com/docs/apis/browser
+- https://capacitorjs.com/docs/apis/app
+- https://capacitorjs.com/docs/guides/deep-links
+- https://capacitorjs.com/docs/guides/storage
+- https://capacitorjs.com/docs/apis/preferences
+- https://capacitorjs.com/docs/guides/security
+
+Community signals from Capacitor issues/discussions:
+
+- Positive reports exist for store-approved apps using Capacitor with OAuth/Auth0/MSAL and mostly core plugins
+- Recurrent pain points include deep-link return handling, Android app-link verification, and auth/browser callback edge cases
+
+Representative sources:
+
+- https://github.com/ionic-team/capacitor/discussions/7305
+- https://github.com/ionic-team/capacitor/discussions/5211
+- https://github.com/ionic-team/capacitor/issues/6300
+- https://github.com/ionic-team/capacitor/issues/5786
+
+Inference:
+
+- Capacitor is a credible path for LucidLedger
+- The hard part is not wrapping the app
+- The hard part is getting login, callback, persistence, and smart-wallet flows reliable on real devices
+
+## `localStorage` And Auth
+
+Question answered:
+
+- Depending on `localStorage` for auth is not automatically wrong
+- It is a common default for web SDKs
+- It is usually not the strongest production design
+
+Main security concern:
+
+- JavaScript can read `localStorage`
+- If malicious JavaScript runs in the app page, it can read tokens stored there and exfiltrate them
+
+This is the XSS concern:
+
+- XSS = cross-site scripting
+- An attacker gets their JavaScript to run in the page
+- If tokens are in `localStorage`, that script can steal them
+
+Why `HttpOnly` cookies are safer:
+
+- Browser sends them automatically with requests
+- Frontend JavaScript cannot read them directly
+- They reduce token theft risk from XSS
+
+Clarification:
+
+- `HttpOnly` cookies do not make XSS harmless
+- They do reduce the risk of raw token theft
+
+## What Privy Docs Say
+
+Privy's docs do not say `localStorage` is forbidden.
+
+Privy's docs do say:
+
+- By default, access tokens are stored in `localStorage`
+- For production web apps, `HttpOnly` cookies are recommended
+- Setting a base domain is recommended so identity tokens can be set as more secure `HttpOnly` cookies
+
+Relevant official Privy docs:
+
+- Configure cookies: https://docs.privy.io/recipes/react/cookies
+- Identity tokens: https://docs.privy.io/user-management/users/identity-tokens
+- Security FAQ: https://docs.privy.io/security/security-faqs
+
+Research on Privy and mobile wrappers:
+
+- Privy has an official Capacitor OAuth recipe: https://docs.privy.io/recipes/capacitor-oauth
+- That recipe uses Capacitor's browser and app plugins plus Universal/App Links
+- It specifically notes OAuth for Capacitor requires Universal App Links over HTTPS and does not work with custom URL schemes
+- A dedicated Privy PWA guide was not found during this research
+- Privy's OAuth docs also note that some providers, such as Google OAuth, may not work in in-app browsers: https://docs.privy.io/authentication/user-authentication/login-methods/oauth
+
+Inference:
+
+- Privy supports Capacitor, but not in a "wrap the web app and auth will automatically behave" sense
+- Mobile callback, storage, and browser handoff still need intentional implementation
+
+## Why The Team May Have Stayed On `localStorage`
+
+Likely reasons:
+
+- It is the simpler initial path
+- The current web SDK flow is easy to wire up
+- The frontend can fetch a token directly and attach it as a bearer token
+- Local development is straightforward when frontend and backend run on separate ports
+
+The current implementation is explicitly built around bearer tokens:
+
+- `client/src/hooks/useAuth.js` gets a token via `getAccessToken()`
+- `client/src/services/api.js` attaches the token as `Authorization: Bearer ...`
+- `server/middleware/authMiddleware.js` expects the token from the header
+
+So the current architecture is not "Privy cookies but not enabled." It is a bearer-token architecture end to end.
+
+## Would Moving To `HttpOnly` Cookies Be Reasonable Next Milestone?
+
+Yes, as a focused auth hardening milestone.
+
+No, if treated as a tiny configuration-only change.
+
+Why it is not trivial:
+
+- Backend auth currently reads bearer headers, not cookies
+- Frontend request behavior would need to change for cookie credentials
+- Cross-origin and cookie settings need to be correct
+- Some app logic currently mixes auth-adjacent behavior with `localStorage` state
+
+Why it is still reasonable:
+
+- Privy already supports cookie-based production web setups
+- Server CORS is already configured with `credentials: true`
+- This is a contained architecture improvement, not a total rewrite
+
+Expected work:
+
+1. Decide on cookie-based web auth flow with Privy
+2. Update frontend requests for cookie-based session use where appropriate
+3. Update backend middleware to support cookie-based token/session reading
+4. Reduce reliance on `localStorage` as the source of truth for auth-adjacent state
+5. Retest login, logout, refresh, role switching, and mobile behavior
+
+Assessment:
+
+- Moderate change
+- Not a one-line switch
+- Reasonable for a next milestone if scoped deliberately
+
+## Recommended Next Steps
+
+1. Treat React Native as a separate future product, not the next web-app milestone
+2. If mobile is needed sooner, evaluate Capacitor first
+3. Make the first Capacitor proof-of-concept only about:
+   - fresh login
+   - callback return
+   - session persistence after close/reopen
+   - smart-wallet creation
+   - one real on-chain action
+4. Before investing more in mobile wrappers, reduce auth fragility in the web app
+5. Plan a cookie-based auth hardening milestone for the web app
+6. Audit and reduce use of `localStorage` for role/pending-action/session orchestration
+
+## Final Practical Takeaway
+
+The app is well positioned to keep one backend and continue as a web-first product.
+
+If a native app is eventually desired:
+
+- React Native is a substantial mobile frontend project
+- Capacitor is much closer to the current architecture
+- PWA/Capacitor auth problems should be expected unless storage, callback handling, and wallet flows are designed intentionally
+
+The most useful near-term move is likely:
+
+- harden auth and persistence first
+- then run a small Capacitor proof-of-concept against the real Privy and wallet flows

--- a/notes/qr-oracle-factory-capabilities.md
+++ b/notes/qr-oracle-factory-capabilities.md
@@ -1,0 +1,184 @@
+# QR Oracle and Factory Capabilities
+
+Last updated: 2026-03-11
+
+## Purpose
+
+This note clarifies what the current v2 contract factory and oracle architecture can already do onchain, what the current QR flow is doing today, and where the gap is between "QR attendance feature" and "registered onchain QR oracle."
+
+This is intentionally about current capability, not future design.
+
+---
+
+## What the Current Factory Can Do
+
+The current v2 factory is modular onchain.
+
+- `WorkContractFactory` maintains an onchain oracle registry keyed by oracle type string.
+- The admin can register a new oracle contract by calling `registerOracle(address oracle)`.
+- At deployment time, the factory resolves requested oracle type strings to oracle contract addresses and passes those oracle contracts into the new `WorkContract`.
+- Each deployed `WorkContract` stores an array of `IWorkOracle` contracts.
+- `approveAndPay()` requires all attached oracles to return `true` before payment is released.
+
+Relevant code:
+- [WorkContractFactory.sol](/Users/ejt/Documents/lucidledger/contracts/src/WorkContractFactory.sol)
+- [WorkContract.sol](/Users/ejt/Documents/lucidledger/contracts/src/WorkContract.sol)
+- [IWorkOracle.sol](/Users/ejt/Documents/lucidledger/contracts/src/interfaces/IWorkOracle.sol)
+
+In other words: the factory is already capable of supporting new oracle types without redeploying the factory itself, as long as there is a real oracle contract implementing `IWorkOracle` and the admin registers it.
+
+---
+
+## What an Oracle Means in the Current Contract Model
+
+In the current onchain model, an oracle is:
+
+- a smart contract that implements `IWorkOracle`
+- exposes `oracleType()`
+- exposes `isWorkVerified(workContract)`
+- can be attached to a `WorkContract` at deployment time through the factory registry
+
+The current `IWorkOracle` interface is boolean. It answers:
+
+- "Has this contract's work been verified yet?"
+
+It does not natively answer:
+
+- "What was the clock-in timestamp?"
+- "What was the clock-out timestamp?"
+- "How many attendance events happened?"
+- "Which kiosk recorded the event?"
+
+So the current oracle architecture is good for gating payment on a yes/no verification condition. It is not, by itself, an attendance-event ledger.
+
+---
+
+## What Is Actually Registered Today
+
+As of now, the app deployment path only treats `manual` as a registered oracle type.
+
+That is visible in the frontend deployment code:
+
+- [AwaitingDeploymentTab.jsx](/Users/ejt/Documents/lucidledger/client/src/EmployerPages/ContractFactory/AwaitingDeploymentTab.jsx)
+
+The deployment UI currently filters selected oracle types down to a hardcoded allowlist:
+
+- `REGISTERED_ORACLE_TYPES = ["manual"]`
+
+That means:
+
+- `manual` is treated as an actual deployable onchain oracle
+- `qr` is currently not
+
+So even though the factory architecture supports modular oracle registration, the current app deployment path does not yet attach a QR oracle to new contracts.
+
+---
+
+## What the Current QR Feature Does Today
+
+The current QR work is mostly app/backend functionality:
+
+- worker generates a QR token
+- kiosk scans it
+- backend validates it
+- backend stores presence events and oracle-verification records
+- frontend shows QR-specific UI and attendance history
+
+Relevant note:
+- [todo-qr-oracle-buildout.md](/Users/ejt/Documents/lucidledger/notes/todo-qr-oracle-buildout.md)
+
+What it does not currently do in a fully onchain sense:
+
+- deploy a `QRCodeOracle` contract
+- register `qr` in the factory registry
+- attach a QR oracle contract to newly deployed `WorkContract`s
+- make `approveAndPay()` depend on QR verification for QR-only contracts
+
+So today QR is best understood as backend-managed attendance evidence, not yet a fully registered onchain oracle.
+
+---
+
+## Practical Consequence for Current Testing
+
+Right now there is an important behavioral difference between selecting `qr` and selecting `qr + manual`.
+
+### If a contract is created with `qr` only
+
+- the UI may still show QR-related controls because it reads `selected_oracles` from the database
+- but the deployment path filters `qr` out
+- the deployed contract ends up with no attached onchain oracle for QR
+- `approveAndPay()` is therefore not blocked by QR verification onchain
+
+### If a contract is created with `qr + manual`
+
+- the QR UI still appears
+- the deployment path keeps `manual`
+- the deployed contract gets the ManualOracle attached
+- payment is oracle-gated onchain, but effectively through `manual`, not through QR
+
+This is why the current QR flow can feel "oracle-like" in the app while not yet being an actual QR oracle from the blockchain's perspective.
+
+---
+
+## What "Registering QR" Actually Means
+
+To make QR a real onchain oracle in the current architecture, the following must happen:
+
+1. Create a `QRCodeOracle.sol` contract that implements `IWorkOracle`
+2. Deploy that contract
+3. Register it in the factory via `registerOracle(qrOracleAddress)`
+4. Update the frontend deployment allowlist so `qr` is no longer filtered out
+5. Ensure the backend calls the QR oracle contract after a validated scan
+
+Only after that sequence will new contracts with `qr` selected actually carry a QR oracle in their onchain oracle array.
+
+---
+
+## Important Limitation of the Current Oracle Interface
+
+Even after QR is registered, the current `IWorkOracle` interface only supports boolean verification.
+
+That means the simplest registered QR oracle would be able to answer:
+
+- "Has this contract had a valid QR verification event yet?"
+
+But it would still not by itself record detailed attendance history onchain.
+
+If the goal is only:
+
+- payment gating based on a verified QR event
+
+then the current oracle architecture is sufficient.
+
+If the goal is also:
+
+- onchain clock-in events
+- onchain clock-out events
+- onchain timestamps
+- onchain attendance audit trail
+
+then that is a separate design step beyond simple oracle registration.
+
+The current architecture can support QR as a yes/no oracle. Recording richer attendance data onchain will require either:
+
+- extending the QR oracle contract to emit per-scan events and/or store more state, or
+- introducing a more expressive oracle/event model than the current boolean interface alone
+
+---
+
+## Bottom Line
+
+The current factory is already modular enough to support new registered onchain oracles.
+
+The gap is not that the factory lacks modularity. The gap is that QR has not yet been completed as a deployed and registered onchain oracle implementation.
+
+Today:
+
+- `manual` is a real onchain oracle in the deployed-contract path
+- `qr` is mostly backend/UI attendance evidence
+
+Next decision:
+
+- decide whether QR only needs to become a boolean onchain verification gate, or whether clock-in/clock-out details themselves need to be recorded onchain
+
+Those are related, but they are not the same task.

--- a/notes/temporal-oracles-and-privacy.md
+++ b/notes/temporal-oracles-and-privacy.md
@@ -1,0 +1,384 @@
+# Temporal Oracles and Privacy
+
+Last updated: 2026-03-11
+
+## Purpose
+
+This note explains why LucidLedger may eventually want to represent verified work time as a duration, rather than only as basic clock-in and clock-out events, and outlines a privacy-preserving way to do that.
+
+This is not a commitment to implement a new oracle model immediately. It is a design note to clarify the tradeoffs.
+
+---
+
+## What "Temporal" Means Here
+
+In this context, a temporal oracle is an oracle that can attest not just that a worker checked in and checked out, but also a derived quantity of verified time.
+
+Examples:
+
+- 480 verified minutes worked
+- 7.5 verified hours on site
+- 6.25 verified hours within the worksite geofence
+- 4 completed check-in windows out of 5 expected windows
+
+This is different from a pure boolean oracle that only answers:
+
+- "Did a valid attendance event happen?"
+- "Has this contract's work been verified?"
+
+---
+
+## Why Duration Can Be Useful
+
+Recording or deriving verified time can be useful for several reasons.
+
+### 1. Better fit for time-based compensation
+
+If payment is ever based on time worked rather than a fixed milestone, the contract or backend needs a quantity that represents payable time.
+
+Clock-in and clock-out events are inputs. Verified duration is the payout-relevant output.
+
+### 2. Better distinction between simple attendance and sustained presence
+
+A worker who checks in once and checks out once is not necessarily equivalent to a worker who was verifiably present throughout the shift.
+
+Duration lets the system distinguish:
+
+- "Two valid scan events occurred"
+- "7.2 verified hours were actually established"
+
+### 3. Supports partial-credit and exception handling
+
+A duration model makes it easier to represent:
+
+- late arrival
+- early departure
+- missed periodic check-ins
+- time spent outside a geofence
+- paid breaks vs unpaid breaks
+- minimum shift thresholds
+
+Instead of reducing all of that to pass/fail, the system can compute payable verified time.
+
+### 4. Better dispute framing
+
+In a dispute, a derived duration can simplify the question.
+
+Instead of reconstructing a shift from many raw events, the dispute can focus on:
+
+- how many verified minutes should count
+- what intervals were excluded and why
+
+This is often more practical than treating every event as equally important.
+
+### 5. Better payroll and reporting primitives
+
+Period-based payroll workflows often want:
+
+- verified hours this week
+- verified minutes this pay cycle
+- attendance compliance percentage
+
+These are naturally expressed as derived time quantities, not just event lists.
+
+---
+
+## Where Duration Is Most Useful
+
+Duration is especially useful for:
+
+- continuous GPS presence
+- periodic check-in systems
+- maritime or journey-based work
+- remote or field work where a single check-in/out pair is too coarse
+
+It is less necessary for:
+
+- simple QR or NFC attendance MVP flows
+- employer-reviewed milestone contracts
+- cases where the main value is audit evidence rather than calculated time
+
+In other words: duration is most valuable when start/end timestamps alone are not enough to capture the real work pattern.
+
+---
+
+## Relationship to Existing Issue Ideas
+
+This note is conceptually related to several existing issues, but not identical to any one of them.
+
+- `#62` introduces the idea of non-boolean oracle outputs via a quantitative interface
+- `#100` introduces continuous presence and track-point storage
+- `#104` introduces app check-in with optional mid-shift check-ins
+- `#102` separates scan method from GPS mode, making richer time logic easier to model
+
+The key distinction is:
+
+- those issues mostly define how presence signals are captured
+- this note focuses on how verified time could be derived from those signals
+
+---
+
+## Privacy Concerns
+
+Yes, temporal verification can raise privacy concerns.
+
+The most important point is this:
+
+- verified duration itself is relatively low sensitivity
+- the raw telemetry needed to compute duration can be highly sensitive
+
+### Lower-sensitivity data
+
+Examples:
+
+- total verified minutes
+- shift start and shift end timestamps
+- count of completed check-in intervals
+- pass/fail geofence summaries
+
+This kind of data is often enough for payment logic and reporting without exposing detailed movement history.
+
+### Higher-sensitivity data
+
+Examples:
+
+- continuous GPS tracks
+- detailed location coordinates over time
+- precise movement patterns during the workday
+- retention of raw traces long after payroll/dispute windows close
+
+This can reveal behavior beyond what is needed to protect wages, including travel routes, break habits, and off-site movements.
+
+That creates real privacy risk, especially for vulnerable workers.
+
+---
+
+## Design Principle: Duration Should Be a Derived Metric
+
+The safest design is to treat verified duration as a derived metric, not as a justification to over-collect raw location data.
+
+Recommended principle:
+
+- collect the minimum raw evidence needed
+- derive verified duration from that evidence
+- retain raw evidence only as long as necessary
+- store and expose summarized results by default
+
+This aligns with LucidLedger's worker-protection framing better than building a high-surveillance telemetry system.
+
+---
+
+## Privacy-Preserving Design for LucidLedger
+
+If LucidLedger adds temporal oracles, the design should favor the following pattern.
+
+### 1. Separate source data from derived results
+
+Raw data examples:
+
+- clock-in event
+- clock-out event
+- periodic check-in event
+- GPS track point
+
+Derived data examples:
+
+- verified_minutes
+- excluded_minutes
+- duration_method
+- confidence or compliance flags
+
+The default reporting surface should prefer derived data over raw telemetry.
+
+### 2. Minimize raw collection by oracle mode
+
+Different oracle modes need different levels of data.
+
+#### QR / NFC scan mode
+
+Usually enough:
+
+- clock-in timestamp
+- clock-out timestamp
+- optional geofence pass/fail
+
+Likely not necessary:
+
+- continuous location history
+
+#### App check-in mode
+
+Usually enough:
+
+- clock-in timestamp
+- clock-out timestamp
+- optional periodic check-in timestamps
+- per-check-in geofence result
+
+Likely sufficient for derived duration without full continuous movement traces.
+
+#### Continuous GPS mode
+
+Most privacy-sensitive. This mode should:
+
+- sample no more frequently than needed
+- derive verified duration server-side
+- avoid exposing raw tracks by default in the UI
+- retain detailed track points for a limited period only
+
+### 3. Retain summaries longer than raw telemetry
+
+Recommended retention model:
+
+- keep derived shift summary longer
+- keep raw detailed telemetry for a short dispute/review window
+- delete or heavily reduce raw location detail after that window
+
+Example:
+
+- retain `verified_minutes`, `clock_in_time`, `clock_out_time`, and summary flags for normal reporting
+- retain detailed `gps_track_points` only for dispute support, then purge or aggregate
+
+The exact retention period should be a policy decision and may vary by jurisdiction.
+
+### 4. Prefer interval summaries over full movement playback
+
+Instead of storing or exposing every movement detail indefinitely, store interval-level results such as:
+
+- 08:00-10:00 verified
+- 10:00-10:20 out of zone
+- 10:20-13:00 verified
+
+This often preserves what matters for payment and disputes without turning the system into a route-history archive.
+
+### 5. On-chain anchoring should use hashes or summaries, not raw traces
+
+If detailed telemetry is ever anchored onchain, privacy risk becomes much higher because onchain data is effectively permanent.
+
+Safer approach:
+
+- anchor a hash of the shift evidence package
+- anchor a hash of a GPS track bundle
+- anchor summarized outputs such as verified minutes
+
+Avoid:
+
+- storing raw coordinates onchain
+- storing full attendance traces onchain
+
+Onchain permanence should be used for integrity, not for publishing sensitive worker telemetry.
+
+### 6. Be explicit about purpose and mode selection
+
+Employers and workers should understand the difference between:
+
+- attendance confirmation
+- geofence-at-scan
+- periodic check-in
+- continuous presence
+
+These are different levels of verification and different levels of privacy impact.
+
+The product should make those tradeoffs explicit at job configuration time.
+
+### 7. Use worker-protective defaults
+
+A worker-protective temporal design would default toward:
+
+- lower-frequency collection where possible
+- summary-first reporting
+- limited raw-retention windows
+- clear rationale for any continuous mode
+
+This is especially important because the platform's mission is not neutral timekeeping alone; it is wage protection.
+
+---
+
+## A Practical Temporal Model
+
+If LucidLedger introduces temporal oracles, a practical model could look like this:
+
+### Per shift summary
+
+Store:
+
+- `clock_in_time`
+- `clock_out_time`
+- `verified_minutes`
+- `excluded_minutes`
+- `verification_method`
+- `verification_summary`
+
+Example `verification_summary`:
+
+```json
+{
+  "mode": "app_checkin",
+  "expected_checkins": 3,
+  "completed_checkins": 3,
+  "geofence_failures": 0,
+  "confidence": "high"
+}
+```
+
+### Optional raw evidence
+
+Store separately and temporarily:
+
+- event timestamps
+- GPS snapshots
+- track points
+- device corroboration fields
+
+This evidence supports disputes, but does not need to be the main long-term product surface.
+
+---
+
+## On-Chain Implications
+
+If the oracle interface ever becomes quantitative, verified time can still fit cleanly into a numeric model.
+
+Possible representation:
+
+- `unitsCompleted(address workContract) -> uint256`
+
+with units defined as:
+
+- verified minutes
+or
+- verified seconds
+
+That means the Solidity type is not the problem. The real design question is:
+
+- what evidence is used to derive the duration
+- how much of that evidence should be persisted
+- what should be recorded onchain versus kept offchain
+
+The privacy-preserving answer is usually:
+
+- compute duration from offchain evidence
+- keep only the minimum necessary summary onchain
+
+---
+
+## Bottom Line
+
+Temporal verification can be genuinely useful because it:
+
+- fits time-based payment better
+- distinguishes attendance from sustained presence
+- supports partial-credit and exception logic
+- simplifies disputes
+- improves payroll-style reporting
+
+But it also raises privacy concerns when it depends on detailed telemetry, especially continuous GPS.
+
+For LucidLedger, the right approach is:
+
+- treat duration as a derived metric
+- collect the minimum raw evidence needed
+- default to summarized outputs
+- limit retention of sensitive raw telemetry
+- anchor hashes or summaries onchain rather than detailed traces
+
+That would allow the platform to support richer time verification without drifting into unnecessary surveillance.

--- a/server/controllers/qrOracleController.js
+++ b/server/controllers/qrOracleController.js
@@ -4,6 +4,7 @@ const { sequelize } = require('../config/database');
 const { QrToken, PresenceEvent, KioskDevice, OracleVerification, DeployedContract, Employee, Employer } = require('../models');
 const { Op } = require('sequelize');
 const { logAction } = require('./auditLogController');
+const { recordVerificationOnChain } = require('../services/qrOracleService');
 
 // Per-kiosk cooldown: track last accepted scan timestamp in memory.
 // Prevents duplicate scans from the camera decode loop (jsQR fires on every frame).
@@ -191,6 +192,11 @@ class QrOracleController {
     const firstName = employee?.first_name || '';
     const lastName = employee?.last_name || '';
     const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+
+    // On-chain oracle verification (non-blocking — never delays kiosk response)
+    if (contract.contract_address) {
+      recordVerificationOnChain(contract.contract_address);
+    }
 
     // Audit log (non-blocking)
     logAction({

--- a/server/services/qrOracleService.js
+++ b/server/services/qrOracleService.js
@@ -1,0 +1,82 @@
+/**
+ * QR Oracle Service
+ *
+ * Calls QRCodeOracle.recordVerification(contractAddress) on-chain
+ * after a successful QR scan is validated by the backend.
+ *
+ * Uses the Lucid Oracle Backend EOA (ORACLE_PRIVATE_KEY) to sign and
+ * submit the transaction. This wallet must have a small ETH balance on
+ * Base for gas (~$0.001/tx).
+ */
+
+const { ethers } = require('ethers');
+
+const QR_ORACLE_ABI = [
+  'function recordVerification(address workContract) external',
+  'function isWorkVerified(address workContract) external view returns (bool)',
+  'function oracleType() external pure returns (string)',
+];
+
+let _oracle = null;
+
+function getOracleContract() {
+  if (_oracle) return _oracle;
+
+  const { ORACLE_PRIVATE_KEY, QR_ORACLE_ADDRESS } = process.env;
+
+  if (!ORACLE_PRIVATE_KEY || !QR_ORACLE_ADDRESS) {
+    console.warn('[QROracle] ORACLE_PRIVATE_KEY or QR_ORACLE_ADDRESS not set — on-chain verification disabled');
+    return null;
+  }
+
+  const rpcUrl = process.env.BASE_RPC_URL || 'https://sepolia.base.org';
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const wallet = new ethers.Wallet(ORACLE_PRIVATE_KEY, provider);
+  _oracle = new ethers.Contract(QR_ORACLE_ADDRESS, QR_ORACLE_ABI, wallet);
+
+  return _oracle;
+}
+
+/**
+ * Record a QR verification on-chain for the given contract address.
+ * Non-blocking — logs errors but does not throw, so a failed on-chain
+ * call never breaks the kiosk scan response.
+ *
+ * @param {string} contractAddress - The deployed WorkContract address
+ * @returns {Promise<string|null>} transaction hash, or null if skipped/failed
+ */
+async function recordVerificationOnChain(contractAddress) {
+  const oracle = getOracleContract();
+  if (!oracle) return null;
+
+  if (!contractAddress) {
+    console.warn('[QROracle] No contract address provided — skipping on-chain verification');
+    return null;
+  }
+
+  try {
+    // Check if already verified to avoid a wasted tx (and revert)
+    const alreadyVerified = await oracle.isWorkVerified(contractAddress);
+    if (alreadyVerified) {
+      console.log(`[QROracle] ${contractAddress} already verified on-chain — skipping`);
+      return null;
+    }
+
+    const tx = await oracle.recordVerification(contractAddress);
+    console.log(`[QROracle] recordVerification tx sent: ${tx.hash}`);
+
+    // Wait for 1 confirmation (non-blocking from caller's perspective via fire-and-forget below)
+    tx.wait(1).then(() => {
+      console.log(`[QROracle] recordVerification confirmed: ${tx.hash}`);
+    }).catch((err) => {
+      console.error(`[QROracle] recordVerification confirmation error: ${err.message}`);
+    });
+
+    return tx.hash;
+  } catch (err) {
+    console.error(`[QROracle] recordVerification failed for ${contractAddress}:`, err.message);
+    return null;
+  }
+}
+
+module.exports = { recordVerificationOnChain };


### PR DESCRIPTION
## Summary
- Add `QRCodeOracle.sol` — singleton `IWorkOracle` implementation, callable only by trusted backend EOA
- Add `deployQRCodeOracle.js` Hardhat deployment script
- Deploy `QRCodeOracle` to Base Sepolia at `0x16Bef41dDB221cEFBEce625d7e456d54f8c43F0E`
- Register `"qr"` oracle type in `WorkContractFactory` via admin UI
- Wire backend to call `recordVerification(contractAddress)` after a successful QR scan via new `qrOracleService.js` (non-blocking)
- Add `"qr"` to `REGISTERED_ORACLE_TYPES` in `AwaitingDeploymentTab` — new contracts with QR selected now have the oracle attached on-chain
- Add `BASE_RPC_URL` and oracle env vars to deploy workflow
- Update `CLAUDE.md` with Docker rebuild and testing workflow rules
- Add research/architecture notes

## Test plan
- [ ] Deploy a new contract with QR oracle selected
- [ ] Worker generates QR on Job Tracker
- [ ] Kiosk scans QR — check backend logs for `[QROracle] recordVerification tx sent: 0x...`
- [ ] Verify `QRCodeOracle.isWorkVerified(contractAddress)` returns `true` on-chain
- [ ] Employer approves payment — should succeed only after scan
- [ ] Employer approves payment on unscanned contract — should revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)