### PR TITLE
feat(#52): QR oracle clock-in/clock-out pair gate + admin remove oracle UI

### DIFF
--- a/client/src/contracts/adminUtils.js
+++ b/client/src/contracts/adminUtils.js
@@ -146,10 +146,45 @@ export const getRegisteredOracle = async (oracleType) => {
   }
 };
 
+/**
+ * Removes an oracle from the WorkContractFactory registry via sponsored transaction.
+ * Must be called from the admin smart wallet.
+ *
+ * @param {Object} params
+ * @param {Object} params.smartWalletClient - Privy smart wallet client
+ * @param {string} params.oracleType - The oracle type string to remove (e.g. "qr")
+ * @param {Function} [params.onStatusChange] - Status callback
+ * @returns {Promise<{txHash: string, basescanUrl: string}>}
+ */
+export const removeOracle = async ({ smartWalletClient, oracleType, onStatusChange }) => {
+  if (!FACTORY_ADDRESS) {
+    throw new Error('VITE_FACTORY_ADDRESS not configured');
+  }
+
+  const data = encodeFunctionData({
+    abi: WorkContractFactoryABI.abi,
+    functionName: 'removeOracle',
+    args: [oracleType],
+  });
+
+  const result = await sendSponsoredTransaction({
+    smartWalletClient,
+    to: getAddress(FACTORY_ADDRESS),
+    data,
+    onStatusChange,
+  });
+
+  return {
+    txHash: result.hash,
+    basescanUrl: `${BASESCAN_URL}/tx/${result.hash}`,
+  };
+};
+
 export default {
   getOnChainAdminAddress,
   isOnChainAdmin,
   deployFactory,
   registerOracle,
+  removeOracle,
   getRegisteredOracle,
 };

--- a/client/src/pages/AdminDeployFactory.jsx
+++ b/client/src/pages/AdminDeployFactory.jsx
@@ -11,7 +11,7 @@ import {
   XCircle,
 } from "lucide-react";
 import apiService from "../services/api";
-import { getOnChainAdminAddress, registerOracle, getRegisteredOracle } from "../contracts/adminUtils";
+import { getOnChainAdminAddress, registerOracle, removeOracle, getRegisteredOracle } from "../contracts/adminUtils";
 import { useAuth } from "../hooks/useAuth";
 import { parseAAError } from "../contracts/aaClient";
 import LogoutButton from "../components/LogoutButton";
@@ -32,6 +32,10 @@ const AdminDeployFactory = () => {
   const [registerResult, setRegisterResult] = useState(null);
   const [registerError, setRegisterError] = useState(null);
   const [manualOracleStatus, setManualOracleStatus] = useState(null);
+  const [qrOracleStatus, setQrOracleStatus] = useState(null);
+  const [removing, setRemoving] = useState(null); // oracle type currently being removed
+  const [removeResult, setRemoveResult] = useState(null);
+  const [removeError, setRemoveError] = useState(null);
 
   const userEmail = user?.email?.address?.toLowerCase() || "";
 
@@ -67,11 +71,36 @@ const AdminDeployFactory = () => {
   // Check oracle registry status
   useEffect(() => {
     const checkOracles = async () => {
-      const addr = await getRegisteredOracle("manual");
-      setManualOracleStatus(addr);
+      const [manual, qr] = await Promise.all([
+        getRegisteredOracle("manual"),
+        getRegisteredOracle("qr"),
+      ]);
+      setManualOracleStatus(manual);
+      setQrOracleStatus(qr);
     };
     checkOracles();
-  }, [registerResult]);
+  }, [registerResult, removeResult]);
+
+  const handleRemoveOracle = async (oracleType) => {
+    if (!smartWalletClient) return;
+    setRemoving(oracleType);
+    setRemoveResult(null);
+    setRemoveError(null);
+    try {
+      const result = await removeOracle({
+        smartWalletClient,
+        oracleType,
+        onStatusChange: ({ step, message }) => {
+          console.log(`Remove oracle: ${step} - ${message}`);
+        },
+      });
+      setRemoveResult(result);
+    } catch (error) {
+      setRemoveError(parseAAError(error));
+    } finally {
+      setRemoving(null);
+    }
+  };
 
   const handleRegisterOracle = async () => {
     if (!oracleAddress || !smartWalletClient) return;
@@ -293,21 +322,58 @@ npx hardhat run scripts/deployFactory.js --network baseSepolia`}
           {/* Current status */}
           <div className="bg-gray-50 rounded-lg p-4 mb-4">
             <p className="text-xs text-gray-500 mb-2">Registered Oracles:</p>
-            <div className="flex items-center gap-2 text-sm">
-              <span className="text-gray-600">manual:</span>
-              {manualOracleStatus ? (
-                <span className="font-mono text-xs text-green-700 flex items-center gap-1">
-                  <CheckCircle className="h-3.5 w-3.5" />
-                  {manualOracleStatus}
-                </span>
-              ) : (
-                <span className="text-amber-600 flex items-center gap-1 text-xs">
-                  <AlertTriangle className="h-3.5 w-3.5" />
-                  Not registered
-                </span>
-              )}
+            <div className="space-y-2">
+              {[{ type: "manual", addr: manualOracleStatus }, { type: "qr", addr: qrOracleStatus }].map(({ type, addr }) => (
+                <div key={type} className="flex items-center justify-between gap-2 text-sm">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-gray-600 shrink-0">{type}:</span>
+                    {addr ? (
+                      <span className="font-mono text-xs text-green-700 flex items-center gap-1 truncate">
+                        <CheckCircle className="h-3.5 w-3.5 shrink-0" />
+                        {addr}
+                      </span>
+                    ) : (
+                      <span className="text-amber-600 flex items-center gap-1 text-xs">
+                        <AlertTriangle className="h-3.5 w-3.5" />
+                        Not registered
+                      </span>
+                    )}
+                  </div>
+                  {addr && (
+                    <button
+                      onClick={() => handleRemoveOracle(type)}
+                      disabled={removing === type || !smartWalletClient}
+                      className="shrink-0 px-2 py-1 text-xs text-red-600 border border-red-200 rounded hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+                    >
+                      {removing === type ? <Loader2 className="h-3 w-3 animate-spin" /> : <XCircle className="h-3 w-3" />}
+                      Remove
+                    </button>
+                  )}
+                </div>
+              ))}
             </div>
           </div>
+
+          {removeResult && (
+            <div className="mb-3 bg-green-50 border border-green-200 rounded-lg p-3">
+              <p className="text-sm text-green-800 flex items-center gap-1">
+                <CheckCircle className="h-4 w-4" />
+                Oracle removed successfully.
+              </p>
+              <a href={removeResult.basescanUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-green-600 underline mt-1 block">
+                View transaction
+              </a>
+            </div>
+          )}
+
+          {removeError && (
+            <div className="mb-3 bg-red-50 border border-red-200 rounded-lg p-3">
+              <p className="text-sm text-red-800 flex items-center gap-1">
+                <XCircle className="h-4 w-4" />
+                Remove failed: {removeError}
+              </p>
+            </div>
+          )}
 
           {/* Register form */}
           <div className="space-y-3">

--- a/contracts/src/oracles/QRCodeOracle.sol
+++ b/contracts/src/oracles/QRCodeOracle.sol
@@ -6,10 +6,19 @@ import "../interfaces/IWorkOracle.sol";
 /**
  * @title QRCodeOracle
  * @dev QR code attendance oracle — the backend server wallet calls
- *      recordVerification() after a valid worker QR scan is validated.
+ *      recordScan() for every clock-in and clock-out event.
  *
  * This is a singleton contract: one QRCodeOracle serves all WorkContracts.
- * Only the trusted backend address (set at deploy time) can record verifications.
+ * Only the trusted backend address (set at deploy time) can record scans.
+ *
+ * Payment gate logic:
+ * - isWorkVerified() returns true only after a complete clock-in → clock-out pair.
+ * - Multiple pairs are supported (worker can clock in/out multiple times).
+ * - Clock-in without clock-out does NOT satisfy the gate.
+ *
+ * Audit trail:
+ * - Every scan (clock-in and clock-out) emits a ScanRecorded event on-chain.
+ * - Full attendance history is permanently visible on the block explorer.
  *
  * In v0.2.0, the employer still calls approveAndPay() manually — QR verification
  * is a prerequisite gate, not an auto-release trigger. Auto-release for QR-only
@@ -18,13 +27,17 @@ import "../interfaces/IWorkOracle.sol";
 contract QRCodeOracle is IWorkOracle {
     address public immutable backend;
 
+    // Payment gate: true after the first complete clock-in → clock-out pair
     mapping(address => bool) private _verified;
 
-    event WorkVerified(address indexed workContract, address indexed recordedBy);
+    // Tracks whether a contract currently has an open clock-in (no matching clock-out yet)
+    mapping(address => bool) private _clockedIn;
+
+    event ScanRecorded(address indexed workContract, bool indexed clockIn, address indexed recordedBy);
 
     /**
-     * @param _backend Address of the trusted backend server wallet that may
-     *                 call recordVerification(). Cannot be changed after deploy.
+     * @param _backend Address of the trusted backend server wallet.
+     *                 Cannot be changed after deploy.
      */
     constructor(address _backend) {
         require(_backend != address(0), "Invalid backend address");
@@ -32,17 +45,24 @@ contract QRCodeOracle is IWorkOracle {
     }
 
     /**
-     * @notice Backend records a successful QR scan verification for a contract.
-     * @param workContract Address of the WorkContract that has been verified
+     * @notice Backend records a QR clock-in or clock-out scan for a contract.
+     * @param workContract Address of the WorkContract being clocked in/out
+     * @param clockIn True for clock-in, false for clock-out
      */
-    function recordVerification(address workContract) external {
-        require(msg.sender == backend, "Only backend can record verification");
+    function recordScan(address workContract, bool clockIn) external {
+        require(msg.sender == backend, "Only backend can record scans");
         require(workContract != address(0), "Invalid contract address");
-        require(!_verified[workContract], "Already verified");
 
-        _verified[workContract] = true;
+        if (clockIn) {
+            require(!_clockedIn[workContract], "Already clocked in");
+            _clockedIn[workContract] = true;
+        } else {
+            require(_clockedIn[workContract], "No active clock-in to close");
+            _clockedIn[workContract] = false;
+            _verified[workContract] = true; // complete pair — gate satisfied
+        }
 
-        emit WorkVerified(workContract, msg.sender);
+        emit ScanRecorded(workContract, clockIn, msg.sender);
     }
 
     /// @inheritdoc IWorkOracle

--- a/server/controllers/qrOracleController.js
+++ b/server/controllers/qrOracleController.js
@@ -4,7 +4,7 @@ const { sequelize } = require('../config/database');
 const { QrToken, PresenceEvent, KioskDevice, OracleVerification, DeployedContract, Employee, Employer } = require('../models');
 const { Op } = require('sequelize');
 const { logAction } = require('./auditLogController');
-const { recordVerificationOnChain } = require('../services/qrOracleService');
+const { recordScanOnChain } = require('../services/qrOracleService');
 
 // Per-kiosk cooldown: track last accepted scan timestamp in memory.
 // Prevents duplicate scans from the camera decode loop (jsQR fires on every frame).
@@ -193,9 +193,9 @@ class QrOracleController {
     const lastName = employee?.last_name || '';
     const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
 
-    // On-chain oracle verification (non-blocking — never delays kiosk response)
+    // On-chain scan record (non-blocking — never delays kiosk response)
     if (contract.contract_address) {
-      recordVerificationOnChain(contract.contract_address);
+      recordScanOnChain(contract.contract_address, eventType);
     }
 
     // Audit log (non-blocking)

--- a/server/services/qrOracleService.js
+++ b/server/services/qrOracleService.js
@@ -1,18 +1,23 @@
 /**
  * QR Oracle Service
  *
- * Calls QRCodeOracle.recordVerification(contractAddress) on-chain
- * after a successful QR scan is validated by the backend.
+ * Calls QRCodeOracle.recordScan(contractAddress, clockIn) on-chain
+ * after every validated QR scan (clock-in or clock-out).
  *
  * Uses the Lucid Oracle Backend EOA (ORACLE_PRIVATE_KEY) to sign and
  * submit the transaction. This wallet must have a small ETH balance on
  * Base for gas (~$0.001/tx).
+ *
+ * Payment gate logic (enforced in QRCodeOracle.sol):
+ * - Clock-in alone does NOT satisfy isWorkVerified()
+ * - A complete clock-in → clock-out pair sets isWorkVerified() = true
+ * - Multiple pairs are supported
  */
 
 const { ethers } = require('ethers');
 
 const QR_ORACLE_ABI = [
-  'function recordVerification(address workContract) external',
+  'function recordScan(address workContract, bool clockIn) external',
   'function isWorkVerified(address workContract) external view returns (bool)',
   'function oracleType() external pure returns (string)',
 ];
@@ -38,45 +43,40 @@ function getOracleContract() {
 }
 
 /**
- * Record a QR verification on-chain for the given contract address.
+ * Record a QR clock-in or clock-out scan on-chain.
  * Non-blocking — logs errors but does not throw, so a failed on-chain
  * call never breaks the kiosk scan response.
  *
  * @param {string} contractAddress - The deployed WorkContract address
+ * @param {string} eventType - 'clock_in' or 'clock_out'
  * @returns {Promise<string|null>} transaction hash, or null if skipped/failed
  */
-async function recordVerificationOnChain(contractAddress) {
+async function recordScanOnChain(contractAddress, eventType) {
   const oracle = getOracleContract();
   if (!oracle) return null;
 
   if (!contractAddress) {
-    console.warn('[QROracle] No contract address provided — skipping on-chain verification');
+    console.warn('[QROracle] No contract address provided — skipping on-chain scan');
     return null;
   }
 
+  const clockIn = eventType === 'clock_in';
+
   try {
-    // Check if already verified to avoid a wasted tx (and revert)
-    const alreadyVerified = await oracle.isWorkVerified(contractAddress);
-    if (alreadyVerified) {
-      console.log(`[QROracle] ${contractAddress} already verified on-chain — skipping`);
-      return null;
-    }
+    const tx = await oracle.recordScan(contractAddress, clockIn);
+    console.log(`[QROracle] recordScan(${eventType}) tx sent: ${tx.hash}`);
 
-    const tx = await oracle.recordVerification(contractAddress);
-    console.log(`[QROracle] recordVerification tx sent: ${tx.hash}`);
-
-    // Wait for 1 confirmation (non-blocking from caller's perspective via fire-and-forget below)
     tx.wait(1).then(() => {
-      console.log(`[QROracle] recordVerification confirmed: ${tx.hash}`);
+      console.log(`[QROracle] recordScan(${eventType}) confirmed: ${tx.hash}`);
     }).catch((err) => {
-      console.error(`[QROracle] recordVerification confirmation error: ${err.message}`);
+      console.error(`[QROracle] recordScan(${eventType}) confirmation error: ${err.message}`);
     });
 
     return tx.hash;
   } catch (err) {
-    console.error(`[QROracle] recordVerification failed for ${contractAddress}:`, err.message);
+    console.error(`[QROracle] recordScan(${eventType}) failed for ${contractAddress}:`, err.message);
     return null;
   }
 }
 
-module.exports = { recordVerificationOnChain };
+module.exports = { recordScanOnChain };


### PR DESCRIPTION
## Summary
- Redesigns `QRCodeOracle.sol` to require a complete clock-in → clock-out pair before `isWorkVerified()` returns true — prevents payment release if worker never clocks out
- Every scan emits a `ScanRecorded` event on-chain (permanent audit trail)
- Updates backend `qrOracleService` to call `recordScan(address, bool)` 
- Adds Remove Oracle button to admin oracle registry UI
- Deployed new oracle at `0x79AebC01E41b969F0889EE006FDCF82E9EE556Bf`, registered with factory

## Test plan
- [ ] Clock in → BlockScout shows `ScanRecorded(clockIn=true)` event
- [ ] Clock out → `ScanRecorded(clockIn=false)` event, payment gate satisfied
- [ ] Double clock-in (no clock-out between) → second clock-in reverts on-chain
- [ ] Payment release works after complete clock-in/clock-out pair
- [ ] Admin UI: Remove Oracle button removes oracle from factory registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)